### PR TITLE
Change pattern of libassimp.so for linux cross compile

### DIFF
--- a/Source/RuntimeMeshLoader/RuntimeMeshLoader.Build.cs
+++ b/Source/RuntimeMeshLoader/RuntimeMeshLoader.Build.cs
@@ -67,10 +67,10 @@ public class RuntimeMeshLoader : ModuleRules
 		if (Target.Platform == UnrealTargetPlatform.Linux)
 		{
 			var AssimpLib = Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "assimp", "lib", "libassimp.so");
-
 			PublicAdditionalLibraries.Add(AssimpLib);
 
-			RuntimeDependencies.Add(AssimpLib);
+			var AssimpLibRuntime = AssimpLib + ".5"; // libassimp.so -> libassimp.so.5
+			RuntimeDependencies.Add(AssimpLibRuntime);
 		}
 	}
 }

--- a/ThirdParty/assimp/lib/libassimp.so
+++ b/ThirdParty/assimp/lib/libassimp.so
@@ -1,0 +1,1 @@
+libassimp.so.5


### PR DESCRIPTION
The Linux program is attempting to load libassimp.so.5 at runtime, which is not automatically copied to the packaged path. This PR enables automatic copying of libassimp.so.5, allowing the built program to run on Linux without any modifications.

Modification:
1. add `libassimp.so.5` as `RuntimeDependencies`
2. add file `libassimp.so.5`
3. convert file `libassimp.so` to a symlink